### PR TITLE
Switch to rsvp from ember-cli/ext/promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 /* jshint node: true */
 'use strict';
 
-var Promise          = require('ember-cli/lib/ext/promise');
+var RSVP             = require('rsvp');
 var DeployPluginBase = require('ember-cli-deploy-plugin');
 var Notify = require('./lib/notify');
 var Service = require('./lib/service');
@@ -40,7 +40,7 @@ function notificationHook(hookName) {
       }
     }
 
-    return Promise.all(promises);
+    return RSVP.all(promises);
   }
 }
 

--- a/lib/notify.js
+++ b/lib/notify.js
@@ -1,9 +1,9 @@
-var Promise    = require('ember-cli/lib/ext/promise');
+var RSVP       = require('rsvp');
 var CoreObject = require('core-object');
 var request    = require('request');
 var merge      = require('lodash/object/merge');
 
-var post = Promise.denodeify(request.post);
+var post = RSVP.denodeify(request.post);
 
 function optsValid(opts) {
   return opts.url && opts.headers && opts.method && opts.body;
@@ -27,7 +27,7 @@ module.exports = CoreObject.extend({
   send: function(serviceKey, opts) {
     var opts        = opts || {};
     var plugin      = this._plugin;
-    var makeRequest = Promise.denodeify(this._client);
+    var makeRequest = RSVP.denodeify(this._client);
     var critical = (('critical' in opts) ? delete opts.critical : false);
 
     var requestOpts = merge(this._defaults(), opts);
@@ -46,7 +46,7 @@ module.exports = CoreObject.extend({
           }
 
           if (critical && !(300 > response.statusCode && response.statusCode >= 200)) {
-            return Promise.reject(response.statusCode);
+            return RSVP.reject(response.statusCode);
           }
 
           plugin.log(serviceKey + ' => ' + body);
@@ -55,7 +55,7 @@ module.exports = CoreObject.extend({
           var errorMessage = serviceKey + ' => ' + error;
 
           if (critical) {
-            return Promise.reject(error);
+            return RSVP.reject(error);
           }
           plugin.log(errorMessage, { color: 'red' });
         });
@@ -63,10 +63,10 @@ module.exports = CoreObject.extend({
       var warningMessage = 'No request issued! Request options invalid! You have to specify `url`, `headers`, `method` and `body`.';
 
       if (critical) {
-        return Promise.reject(warningMessage);
+        return RSVP.reject(warningMessage);
       }
       plugin.log(serviceKey+' => '+warningMessage, { color: 'yellow', verbose: true });
-      return Promise.resolve();
+      return RSVP.resolve();
     }
   }
 });

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "ember-cli-babel": "^5.1.5",
     "ember-cli-deploy-plugin": "0.2.0",
     "lodash": "^3.10.1",
-    "request": "^2.65.0"
+    "request": "^2.65.0",
+    "rsvp": "^3.5.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
In ember-cli 2.12:

```
DEPRECATION: `ember-cli/ext/promise` is deprecated, use `rsvp` instead. Required here: 
  Object.<anonymous> (/node_modules/ember-cli-deploy-webhooks/index.js:4:24)
DEPRECATION: `ember-cli/ext/promise` is deprecated, use `rsvp` instead. Required here: 
  Object.<anonymous> (/node_modules/ember-cli-deploy-webhooks/lib/notify.js:1:80)
```

This PR switches from `ember-cli/lib/ext/promise` to `rsvp` as recommended by the deprecation warnings.