### PR TITLE
start a 1.0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-deploy-webhooks",
-  "version": "0.4.2",
+  "version": "1.0.0-beta.1",
   "description": "Ember CLI Deploy plugin for calling webhooks during deployments",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
Looks like this addon is really stable and could be bumped to 1.0
What else needs to be done to move `ember-cli-deploy-webhooks` to 1.0?

This PR bumps the version to `1.0.0-beta.1`
Can we cut a npm release for this. 

Thanks for maintaining this project.

Cheers
Dave
